### PR TITLE
Update coveralls and cssmin dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@turf/turf": "^4.3.1",
     "browserify-istanbul": "^2.0.0",
-    "coveralls": "^2.11.15",
+    "coveralls": "^2.13.1",
     "expect.js": "~0.3.1",
     "grunt": "^1.0.1",
     "grunt-browserify": "^5.0.0",
@@ -34,7 +34,7 @@
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-csslint": "^2.0.0",
-    "grunt-contrib-cssmin": "^2.0.0",
+    "grunt-contrib-cssmin": "^2.2.0",
     "grunt-contrib-jshint": "^1.1.0",
     "grunt-contrib-uglify": "^3.0.1",
     "grunt-gh-pages": "^2.0.0",


### PR DESCRIPTION
Update outdated dependencies to latest versions of coveralls and cssmin.